### PR TITLE
Fix interpolated string `Failed to generate docs...`

### DIFF
--- a/.changeset/sixty-monkeys-deny.md
+++ b/.changeset/sixty-monkeys-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Fix interpolated string for "Failed to generate docs from ..."

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -150,7 +150,7 @@ export class TechdocsGenerator implements GeneratorBase {
         `Failed to generate docs from ${inputDir} into ${outputDir}`,
       );
       throw new ForwardedError(
-        'Failed to generate docs from ${inputDir} into ${outputDir}',
+        `Failed to generate docs from ${inputDir} into ${outputDir}`,
         error,
       );
     }


### PR DESCRIPTION
A string was using the wrong kind of quotes and so the interpolated fields weren't.

Signed-off-by: Oliver Paraskos <oliver@tryflux.com>

## Hey, I just made a Pull Request!

![Screenshot 2022-01-20 at 10 52 28](https://user-images.githubusercontent.com/8076088/150325038-3236f53d-565b-429a-b8cf-61d91cea94a4.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
